### PR TITLE
Fixed embed link to yt video

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ The Adobe Experience Platform SDK is required to power Adobe's Experience Cloud 
 
 To implement the SDK, create a mobile property in Adobe Experience Platform Launch, set up the configuration required by the Mobile Core and and by other extensions you may add, and publish the configuration into an environment. To initialize the SDK in your app, you'll reference the environment to get started.
 
-{% embed url="https://www.youtube.com/watch?v=p\_TZ6\_z2D0E" caption="" %}
+Launch & Mobile - Trailer
 
+[![](https://img.youtube.com/vi/p_TZ6_z2D0E/0.jpg)](http://www.youtube.com/watch?v=p_TZ6_z2D0E "Adobe Experience Platform Launch")
 ## Quick Links
 
 * [Getting started](getting-started/create-a-mobile-property.md)


### PR DESCRIPTION
Added clickable image to yt video because markdown does not support embed youtube via embed url.